### PR TITLE
Accept only 8-bit images

### DIFF
--- a/src/main/java/volumeCalculator/Volume_Calculator.java
+++ b/src/main/java/volumeCalculator/Volume_Calculator.java
@@ -81,7 +81,7 @@ public class Volume_Calculator implements PlugInFilter {
         if (null != imagePlus) {
             this.originalImage = (new Duplicator()).run(imagePlus);
         }
-        return DOES_ALL + STACK_REQUIRED;           // Gotta have a Stack!
+        return DOES_8G + STACK_REQUIRED;           // Gotta have a Stack!
     }
 
     /**


### PR DESCRIPTION
This plugin runs Skeletonize3D_ which accepts 8-bit images only. (Fixes a bug reported on [fiji-devel](https://groups.google.com/forum/#!topic/fiji-devel/clzTThrZgQ0) by Bryan Melendez)
